### PR TITLE
Upgrade react-native-masked-view package

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -471,7 +471,7 @@ PODS:
     - React-perflogger (= 0.71.6)
   - RNCAsyncStorage (1.17.11):
     - React-Core
-  - RNCMaskedView (0.2.8):
+  - RNCMaskedView (0.2.9):
     - React-Core
   - RNGestureHandler (2.9.0):
     - React-Core
@@ -781,7 +781,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 8692ac548bec648fa121980ccb4304afd136d584
   ReactCommon: 0982e4657e0ecdc3a90858fbb529d54cd0be8fb4
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
-  RNCMaskedView: bc0170f389056201c82a55e242e5d90070e18e5a
+  RNCMaskedView: 949696f25ec596bfc697fc88e6f95cf0c79669b6
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
   rnmapbox-maps: 183ed3cb6ebde0c0492fefa652c05175730035ce
   RNReanimated: cc5e3aa479cb9170bcccf8204291a6950a3be128

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@expo-google-fonts/comfortaa": "^0.2.3",
         "@expo-google-fonts/roboto": "^0.2.3",
         "@react-native-async-storage/async-storage": "1.17.11",
-        "@react-native-masked-view/masked-view": "0.2.8",
+        "@react-native-masked-view/masked-view": "0.2.9",
         "@react-navigation/bottom-tabs": "^6.5.7",
         "@react-navigation/native": "^6.1.6",
         "@react-navigation/native-stack": "^6.9.12",
@@ -6003,9 +6003,9 @@
       }
     },
     "node_modules/@react-native-masked-view/masked-view": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@react-native-masked-view/masked-view/-/masked-view-0.2.8.tgz",
-      "integrity": "sha512-+1holBPDF1yi/y0uc1WB6lA5tSNHhM7PpTMapT3ypvSnKQ9+C6sy/zfjxNxRA/llBQ1Ci6f94EaK56UCKs5lTA==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@react-native-masked-view/masked-view/-/masked-view-0.2.9.tgz",
+      "integrity": "sha512-Hs4vKBKj+15VxHZHFtMaFWSBxXoOE5Ea8saoigWhahp8Mepssm0ezU+2pTl7DK9z8Y9s5uOl/aPb4QmBZ3R3Zw==",
       "peerDependencies": {
         "react": ">=16",
         "react-native": ">=0.57"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@expo-google-fonts/comfortaa": "^0.2.3",
     "@expo-google-fonts/roboto": "^0.2.3",
     "@react-native-async-storage/async-storage": "1.17.11",
-    "@react-native-masked-view/masked-view": "0.2.8",
+    "@react-native-masked-view/masked-view": "0.2.9",
     "@react-navigation/bottom-tabs": "^6.5.7",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",


### PR DESCRIPTION
Upgraded the `react-native-masked-view` package from version 0.2.8 to 0.2.9 which fixes a type error when using the `MaskedView` component:
<img width="677" alt="image" src="https://user-images.githubusercontent.com/43038541/231854815-b7614ba6-c10c-4b07-868e-50d85f7e7bcc.png">

See `react-native-masked-view`'s PR to fix this issue here: https://github.com/react-native-masked-view/masked-view/pull/187