### PR TITLE
Specify shouldCancelWhenOutside to be false on long press gesture

### DIFF
--- a/src/components/emergency/EmergencyButton.tsx
+++ b/src/components/emergency/EmergencyButton.tsx
@@ -284,6 +284,7 @@ const EmergencyButton = () => {
   const longPressGesture: LongPressGesture = Gesture.LongPress()
     .minDuration(EMERGENCY_TIME_THRESHOLD)
     .maxDistance(DEVICE_HEIGHT) // weird behavior-value pairing...?
+    .shouldCancelWhenOutside(false)
     .onStart(() => {
       // At start of long press...
       runOnJS(hideMoodsHandler)();


### PR DESCRIPTION
Fixed recent issue of which the emergency button overlay would disappear if it is slid up too quickly. The fix uses the option `shouldCancelWhenOutside` as `false` on the long press gesture. According to React Native Gesture Handler's documentation, the property is common across all gestures, not just the long press gesture. However, the default value of this property is `true` for the long press gesture as well as the tap gesture.

<img width="664" alt="image" src="https://user-images.githubusercontent.com/43038541/231867433-58e90bfd-b768-4fa9-98a3-30abeab976f8.png">

Not sure why / how this broke or how it was working before...